### PR TITLE
Updates

### DIFF
--- a/examples/auth/scalekit_oauth/README.md
+++ b/examples/auth/scalekit_oauth/README.md
@@ -32,24 +32,20 @@ The Scalekit OAuth provider enables authentication using Scalekit's OAuth 2.0 an
    - Set up your SSO connection (SAML, OIDC, or OAuth provider)
    - Configure the connection for your organization
 
-### 2. Environment Variables
-
-Create a `.env` file in this directory:
+### 2. Set Environment Variables
 
 ```bash
 # Required Scalekit credentials
-SCALEKIT_ENVIRONMENT_URL=https://your-env.scalekit.com
-SCALEKIT_CLIENT_ID=sk_client_123
-SCALEKIT_RESOURCE_ID=sk_resource_456
-
-# MCP Server URL (optional, defaults to http://localhost:8000/mcp)
-# SCALEKIT_MCP_URL=http://localhost:8000/mcp
+export SCALEKIT_ENVIRONMENT_URL="https://your-env.scalekit.com"
+export SCALEKIT_CLIENT_ID="sk_123"
+export SCALEKIT_RESOURCE_ID="res_456"
+export SCALEKIT_MCP_URL="http://localhost:8000/mcp"
 ```
 
 ### 3. Install Dependencies
 
 ```bash
-cd /Users/ravimadabhushi/Documents/fastmcp
+cd /path/to/fastmcp
 uv sync
 ```
 
@@ -147,7 +143,6 @@ FileTokenStorage.clear_all()
 
 ## Security Notes
 
-- Never commit `.env` files with real credentials
 - Use HTTPS in production
 - Rotate client secrets regularly
 - Monitor Scalekit logs for unusual activity

--- a/examples/auth/scalekit_oauth/README.md
+++ b/examples/auth/scalekit_oauth/README.md
@@ -42,8 +42,8 @@ SCALEKIT_ENVIRONMENT_URL=https://your-env.scalekit.com
 SCALEKIT_CLIENT_ID=sk_client_123
 SCALEKIT_RESOURCE_ID=sk_resource_456
 
-# Server URL (optional, defaults to http://localhost:8000)
-# SERVER_BASE_URL=http://localhost:8000
+# MCP Server URL (optional, defaults to http://localhost:8000/mcp)
+# SCALEKIT_MCP_URL=http://localhost:8000/mcp
 ```
 
 ### 3. Install Dependencies

--- a/examples/auth/scalekit_oauth/client.py
+++ b/examples/auth/scalekit_oauth/client.py
@@ -28,9 +28,9 @@ async def main():
             result = await client.call_tool("echo", {"message": "Hello from Scalekit!"})
             print(f"🎯 Echo result: {result}")
 
-            # Test calling user info tool
-            user_info = await client.call_tool("get_user_info", {})
-            print(f"👤 User info: {user_info}")
+            # Test calling auth status tool
+            auth_status = await client.call_tool("auth_status", {})
+            print(f"👤 Auth status: {auth_status}")
 
     except Exception as e:
         print(f"❌ Authentication failed: {e}")

--- a/examples/auth/scalekit_oauth/server.py
+++ b/examples/auth/scalekit_oauth/server.py
@@ -20,7 +20,7 @@ auth = ScalekitProvider(
     environment_url=os.getenv("SCALEKIT_ENVIRONMENT_URL") or "https://your-env.scalekit.com",
     client_id=os.getenv("SCALEKIT_CLIENT_ID") or "",
     resource_id=os.getenv("SCALEKIT_RESOURCE_ID") or "",
-    base_url="http://localhost:8000",
+    mcp_url=os.getenv("SCALEKIT_MCP_URL", "http://localhost:8000/mcp")
 )
 
 mcp = FastMCP("Scalekit OAuth Example Server", auth=auth)
@@ -33,8 +33,8 @@ def echo(message: str) -> str:
 
 
 @mcp.tool
-def get_user_info() -> dict:
-    """Get information about the authenticated user."""
+def auth_status() -> dict:
+    """Show Scalekit authentication status."""
     # In a real implementation, you would extract user info from the JWT token
     return {
         "message": "This tool requires authentication via Scalekit",

--- a/src/fastmcp/server/auth/providers/scalekit.py
+++ b/src/fastmcp/server/auth/providers/scalekit.py
@@ -159,7 +159,7 @@ class ScalekitProvider(RemoteAuthProvider):
             try:
                 async with httpx.AsyncClient() as client:
                     response = await client.get(
-                        f"{self.environment_url}/resources/{self.resource_id}/.well-known/oauth-authorization-server"
+                        f"{self.environment_url}/.well-known/oauth-authorization-server/resources/{self.resource_id}"
                     )
                     response.raise_for_status()
                     metadata = response.json()

--- a/src/fastmcp/server/auth/providers/scalekit.py
+++ b/src/fastmcp/server/auth/providers/scalekit.py
@@ -33,7 +33,7 @@ class ScalekitProviderSettings(BaseSettings):
     environment_url: AnyHttpUrl
     client_id: str
     resource_id: str
-    base_url: AnyHttpUrl
+    mcp_url: AnyHttpUrl
 
 
 class ScalekitProvider(RemoteAuthProvider):
@@ -49,7 +49,7 @@ class ScalekitProvider(RemoteAuthProvider):
        - Go to your [Scalekit Dashboard](https://app.scalekit.com/)
        - Navigate to MCP Servers section
        - Register a new MCP Server with appropriate scopes
-       - Ensure the Resource Identifier matches exactly what you configure as Server Base URl
+       - Ensure the Resource Identifier matches exactly what you configure as MCP URL
        - Note the Resource ID
 
     2. Configure OAuth Client:
@@ -61,7 +61,7 @@ class ScalekitProvider(RemoteAuthProvider):
        - Set SCALEKIT_ENVIRONMENT_URL (e.g., https://your-env.scalekit.com)
        - Set SCALEKIT_CLIENT_ID from your OAuth application
        - Set SCALEKIT_RESOURCE_ID from your created resource
-       - Set SERVER_BASE_URL to your FastMCP server's public URL
+       - Set SCALEKIT_MCP_URL to your FastMCP server's public URL
 
     For detailed setup instructions, see:
     https://docs.scalekit.com/mcp/oauth/
@@ -75,7 +75,7 @@ class ScalekitProvider(RemoteAuthProvider):
             environment_url="https://your-env.scalekit.com",
             client_id="sk_client_...",
             resource_id="sk_resource_...",
-            base_url="https://your-fastmcp-server.com",
+            mcp_url="https://your-fastmcp-server.com",
         )
 
         # Use with FastMCP
@@ -89,7 +89,7 @@ class ScalekitProvider(RemoteAuthProvider):
         environment_url: AnyHttpUrl | str | NotSetT = NotSet,
         client_id: str | NotSetT = NotSet,
         resource_id: str | NotSetT = NotSet,
-        base_url: AnyHttpUrl | str | NotSetT = NotSet,
+        mcp_url: AnyHttpUrl | str | NotSetT = NotSet,
         token_verifier: TokenVerifier | None = None,
     ):
         """Initialize Scalekit resource server provider.
@@ -98,7 +98,7 @@ class ScalekitProvider(RemoteAuthProvider):
             environment_url: Your Scalekit environment URL (e.g., "https://your-env.scalekit.com")
             client_id: Your Scalekit OAuth client ID
             resource_id: Your Scalekit resource ID
-            base_url: Public URL of this FastMCP server (used as audience)
+            mcp_url: Public URL of this FastMCP server (used as audience)
             token_verifier: Optional token verifier. If None, creates JWT verifier for Scalekit
         """
         settings = ScalekitProviderSettings.model_validate(
@@ -108,7 +108,7 @@ class ScalekitProvider(RemoteAuthProvider):
                     "environment_url": environment_url,
                     "client_id": client_id,
                     "resource_id": resource_id,
-                    "base_url": base_url,
+                    "mcp_url": mcp_url,
                 }.items()
                 if v is not NotSet
             }
@@ -117,7 +117,7 @@ class ScalekitProvider(RemoteAuthProvider):
         self.environment_url = str(settings.environment_url).rstrip("/")
         self.client_id = settings.client_id
         self.resource_id = settings.resource_id
-        self.base_url = str(settings.base_url).rstrip("/")
+        self.mcp_url = str(settings.mcp_url)
 
         # Create default JWT verifier if none provided
         if token_verifier is None:
@@ -125,7 +125,7 @@ class ScalekitProvider(RemoteAuthProvider):
                 jwks_uri=f"{self.environment_url}/keys",
                 issuer=self.environment_url,
                 algorithm="RS256",
-                audience=self.base_url,
+                audience=self.mcp_url,
             )
 
         # Initialize RemoteAuthProvider with Scalekit as the authorization server
@@ -134,7 +134,7 @@ class ScalekitProvider(RemoteAuthProvider):
             authorization_servers=[
                 AnyHttpUrl(f"{self.environment_url}/resources/{self.resource_id}")
             ],
-            base_url=self.base_url,
+            base_url=self.mcp_url,
         )
 
     def get_routes(


### PR DESCRIPTION
This pr brings in the following update:
1. Updating authorization metadata endpoint
2. Calling mcp_url explicitly instead of base_url to avoid confusion
3. Updating tool name from get_user_info to auth_status
4. Removed `rstrip()` from base_url/mcp_url
